### PR TITLE
*: Support single DHT only

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,39 +1,6 @@
 # max_mind_db_path = "<path to GeoLite2-City.mmdb>"
 # cloud_provider_cidr_db_path = "<path to cidrs.csv>"
 
-[[dhts]]
-name = "kusama"
-bootnodes = [
-    "/dns/p2p.cc3-0.kusama.network/tcp/30100/p2p/12D3KooWDgtynm4S9M3m6ZZhXYu2RrWKdvkCSScc25xKDVSg1Sjd",
-    "/dns/p2p.cc3-1.kusama.network/tcp/30100/p2p/12D3KooWNpGriWPmf621Lza9UWU9eLLBdCFaErf6d4HSK7Bcqnv4",
-    "/dns/p2p.cc3-2.kusama.network/tcp/30100/p2p/12D3KooWLmLiB4AenmN2g2mHbhNXbUcNiGi99sAkSk1kAQedp8uE",
-    "/dns/p2p.cc3-3.kusama.network/tcp/30100/p2p/12D3KooWEGHw84b4hfvXEfyq4XWEmWCbRGuHMHQMpby4BAtZ4xJf",
-    "/dns/p2p.cc3-4.kusama.network/tcp/30100/p2p/12D3KooWF9KDPRMN8WpeyXhEeURZGP8Dmo7go1tDqi7hTYpxV9uW",
-    "/dns/p2p.cc3-5.kusama.network/tcp/30100/p2p/12D3KooWDiwMeqzvgWNreS9sV1HW3pZv1PA7QGA7HUCo7FzN5gcA",
-    "/dns/kusama-bootnode-0.paritytech.net/tcp/30333/p2p/12D3KooWSueCPH3puP2PcvqPJdNaDNF3jMZjtJtDiSy35pWrbt5h",
-    "/dns/kusama-bootnode-0.paritytech.net/tcp/30334/ws/p2p/12D3KooWSueCPH3puP2PcvqPJdNaDNF3jMZjtJtDiSy35pWrbt5h",
-    "/dns/kusama-bootnode-1.paritytech.net/tcp/30333/p2p/12D3KooWQKqane1SqWJNWMQkbia9qiMWXkcHtAdfW5eVF8hbwEDw"]
-disjoint_query_paths = false
-protocol_name = "/ksmcc3/kad"
-noise_legacy = true
-
-[[dhts]]
-name = "kusama-disjoint"
-bootnodes = [
-    "/dns/p2p.cc3-0.kusama.network/tcp/30100/p2p/12D3KooWDgtynm4S9M3m6ZZhXYu2RrWKdvkCSScc25xKDVSg1Sjd",
-    "/dns/p2p.cc3-1.kusama.network/tcp/30100/p2p/12D3KooWNpGriWPmf621Lza9UWU9eLLBdCFaErf6d4HSK7Bcqnv4",
-    "/dns/p2p.cc3-2.kusama.network/tcp/30100/p2p/12D3KooWLmLiB4AenmN2g2mHbhNXbUcNiGi99sAkSk1kAQedp8uE",
-    "/dns/p2p.cc3-3.kusama.network/tcp/30100/p2p/12D3KooWEGHw84b4hfvXEfyq4XWEmWCbRGuHMHQMpby4BAtZ4xJf",
-    "/dns/p2p.cc3-4.kusama.network/tcp/30100/p2p/12D3KooWF9KDPRMN8WpeyXhEeURZGP8Dmo7go1tDqi7hTYpxV9uW",
-    "/dns/p2p.cc3-5.kusama.network/tcp/30100/p2p/12D3KooWDiwMeqzvgWNreS9sV1HW3pZv1PA7QGA7HUCo7FzN5gcA",
-    "/dns/kusama-bootnode-0.paritytech.net/tcp/30333/p2p/12D3KooWSueCPH3puP2PcvqPJdNaDNF3jMZjtJtDiSy35pWrbt5h",
-    "/dns/kusama-bootnode-0.paritytech.net/tcp/30334/ws/p2p/12D3KooWSueCPH3puP2PcvqPJdNaDNF3jMZjtJtDiSy35pWrbt5h",
-    "/dns/kusama-bootnode-1.paritytech.net/tcp/30333/p2p/12D3KooWQKqane1SqWJNWMQkbia9qiMWXkcHtAdfW5eVF8hbwEDw"]
-disjoint_query_paths = true
-protocol_name = "/ksmcc3/kad"
-noise_legacy = true
-
-[[dhts]]
 name = "ipfs"
 bootnodes = ["/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"]
 disjoint_query_paths = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,28 +1,22 @@
 use libp2p::core::Multiaddr;
 use serde_derive::Deserialize;
-use std::path::PathBuf;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Config {
     pub max_mind_db_path: Option<PathBuf>,
     pub cloud_provider_cidr_db_path: Option<PathBuf>,
 
-    pub dhts: Vec<DhtConfig>,
+    pub bootnodes: Vec<Multiaddr>,
+    pub disjoint_query_paths: bool,
+    pub protocol_name: Option<String>,
+    pub noise_legacy: bool,
+    pub listen_address: Option<SocketAddr>,
 }
 
 impl Config {
     pub fn from_file(path: PathBuf) -> Self {
         toml::from_str(&std::fs::read_to_string(path).unwrap()).unwrap()
     }
-}
-
-#[derive(Clone, Debug, Deserialize)]
-pub struct DhtConfig {
-    pub name: String,
-    pub bootnodes: Vec<Multiaddr>,
-    pub disjoint_query_paths: bool,
-    pub protocol_name: Option<String>,
-    pub noise_legacy: bool,
-    pub listen_address: Option<SocketAddr>,
 }

--- a/src/exporter/client.rs
+++ b/src/exporter/client.rs
@@ -1,4 +1,4 @@
-use crate::config::DhtConfig;
+use crate::config::Config;
 use futures::executor::block_on;
 use futures::prelude::*;
 use futures::ready;
@@ -22,6 +22,7 @@ use libp2p::{
     },
     tcp, yamux, InboundUpgradeExt, NetworkBehaviour, OutboundUpgradeExt, PeerId, Swarm,
 };
+use open_metrics_client::registry::Registry;
 use std::sync::Arc;
 use std::{
     error::Error,
@@ -31,7 +32,6 @@ use std::{
     time::Duration,
     usize,
 };
-use open_metrics_client::registry::Registry;
 
 mod global_only;
 
@@ -42,7 +42,7 @@ pub struct Client {
 }
 
 impl Client {
-    pub fn new(config: DhtConfig, registry: &mut Registry) -> Result<Client, Box<dyn Error>> {
+    pub fn new(config: Config, registry: &mut Registry) -> Result<Client, Box<dyn Error>> {
         // Create a random key for ourselves.
         let local_key = Keypair::generate_ed25519();
         let local_peer_id = PeerId::from(local_key.public());
@@ -127,8 +127,8 @@ impl Stream for Client {
                         Event::Identify(e) => self.metrics.record(e.as_ref()),
                         Event::Kademlia(e) => self.metrics.record(e.as_ref()),
                     }
-                    return Poll::Ready(Some(event))
-                } ,
+                    return Poll::Ready(Some(event));
+                }
                 SwarmEvent::NewListenAddr { address, .. } => {
                     println!("Swarm listening on {:?}", address);
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,12 +44,13 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let ip_db = config
         .max_mind_db_path
+        .clone()
         .map(|path| maxminddb::Reader::open_readfile(path).expect("Failed to open max mind db."));
     let cloud_provider_db = config
         .cloud_provider_cidr_db_path
+        .clone()
         .map(|path| cloud_provider_db::Db::new(path).expect("Failed to parse cloud provider db."));
-    let exporter =
-        exporter::Exporter::new(config.dhts, ip_db, cloud_provider_db, &mut registry)?;
+    let exporter = exporter::Exporter::new(config, ip_db, cloud_provider_db, &mut registry)?;
 
     let registry = Arc::new(Mutex::new(registry));
 


### PR DESCRIPTION
Instead of scraping multiple DHTs with a single exporter, run one
exporter per DHT.